### PR TITLE
Require password to authenticate user

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -7,4 +7,5 @@ class User < ActiveRecord::Base
   devise :database_authenticatable, :registerable, :trackable
 
   validates :authentication_token, presence: true
+  validates :password, on: :create, presence: true
 end

--- a/db/migrate/20150302005339_add_encrypted_password_to_users.rb
+++ b/db/migrate/20150302005339_add_encrypted_password_to_users.rb
@@ -1,0 +1,5 @@
+class AddEncryptedPasswordToUsers < ActiveRecord::Migration
+  def change
+    add_column :users, :encrypted_password, :string, null: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20150218233225) do
+ActiveRecord::Schema.define(version: 20150302005339) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -56,6 +56,7 @@ ActiveRecord::Schema.define(version: 20150218233225) do
     t.inet     "last_sign_in_ip"
     t.datetime "created_at"
     t.datetime "updated_at"
+    t.string   "encrypted_password",               null: false
   end
 
   add_index "users", ["authentication_token"], name: "index_users_on_authentication_token", using: :btree

--- a/spec/controllers/sessions_controller_spec.rb
+++ b/spec/controllers/sessions_controller_spec.rb
@@ -2,22 +2,54 @@ require 'rails_helper'
 
 RSpec.describe SessionsController, type: :controller do
   describe '#create' do
-    it 'creates brand new user' do
-      request.headers['X-User-Token'] = 'mathematical'
-      post :create, email: 'finn@ooo.com'
+    
+    context 'when the data is valid' do
+      it 'creates brand new user' do
+        request.headers['X-User-Token'] = 'mathematical'
+        post :create, email: 'finn@ooo.com', password: 'testpass'
 
-      expect(assigns(:user).email).to eq('finn@ooo.com')
-      expect(assigns(:user).authentication_token).to eq('mathematical')
+        expect(User.count).to eq(1)
+        expect(assigns(:user).email).to eq('finn@ooo.com')
+        expect(assigns(:user).authentication_token).to eq('mathematical')
+        expect(response.status).to eql(200)
+      end
+
+      it 'updates authentication_token if new user token is passed with existing email' do
+        user = create(:user, password: 'testpass')
+
+        request.headers['X-User-Token'] = 'mathematical'
+        post :create, email: user.email, password: 'testpass'
+
+        expect(User.count).to eq(1)
+        expect(assigns(:user).authentication_token).to eq('mathematical')
+        expect(response.status).to eql(200)
+      end
     end
 
-    it 'updates authentication_token if new user token is passed with existing email' do
-      user = create(:user)
+    context 'when the data is invalid' do
+      it 'does not create an user without a password' do
+        request.headers['X-User-Token'] = 'mathematical'
+        post :create, email: 'finn@ooo.com'
 
-      request.headers['X-User-Token'] = 'mathematical'
-      post :create, email: user.email
+        expect(User.count).to eq(0)
+        expect(response.status).to eql(401)
+      end
 
-      expect(User.count).to eq(1)
-      expect(assigns(:user).authentication_token).to eq('mathematical')
+      it 'does not create an user without an authentication_token' do
+        post :create, email: 'finn@ooo.com', password: 'testpass'
+
+        expect(User.count).to eq(0)
+        expect(response.status).to eql(401)
+      end
+
+      it 'fails to login with the wrong password' do
+        user = create(:user)
+
+        request.headers['X-User-Token'] = 'mathematical'
+        post :create, email: user.email, password: "wrong #{user.password}"
+
+        expect(response.status).to eql(401)
+      end
     end
   end
 end

--- a/spec/factories.rb
+++ b/spec/factories.rb
@@ -10,6 +10,8 @@ FactoryGirl.define do
   end
 
   factory :user do
-    authentication_token {|n| "token-#{n}" }
+    sequence(:email) {|n| "email_#{n}@foo.bar"}
+    sequence(:authentication_token) {|n| "token-#{n}" }
+    sequence(:password) {|n| "password-#{n}"}
   end
 end


### PR DESCRIPTION
This commit:
- adds encrypted_password to User
- validates password presence when creating a new user
- finds or creates an user on sessions#create:
  - when it fails due to invalid data, returns an error message
  - when the email and password are correct, returns the authentication token from user.
