### PR TITLE
Bounties/188

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -6,6 +6,7 @@ ruby '2.2.0'
 gem 'active_model_serializers',
   github: 'rails-api/active_model_serializers',
   branch: '0-8-stable'
+gem 'aws-sdk-v1'
 gem 'devise'
 gem 'faraday', '~> 0.9.1'
 gem 'pg'

--- a/Gemfile
+++ b/Gemfile
@@ -10,6 +10,7 @@ gem 'devise'
 gem 'faraday', '~> 0.9.1'
 gem 'pg'
 gem 'lograge'
+gem 'paperclip'
 gem 'puma'
 gem 'rails', '4.2.0'
 gem 'rails_stdout_logging', group: [:development, :production]

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -45,6 +45,9 @@ GEM
       thread_safe (~> 0.3, >= 0.3.4)
       tzinfo (~> 1.1)
     arel (6.0.0)
+    aws-sdk-v1 (1.63.0)
+      json (~> 1.4)
+      nokogiri (>= 1.4.4)
     bcrypt (3.1.10)
     builder (3.2.2)
     byebug (3.5.1)
@@ -197,6 +200,7 @@ PLATFORMS
 
 DEPENDENCIES
   active_model_serializers!
+  aws-sdk-v1
   byebug
   devise
   factory_girl_rails

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -53,6 +53,10 @@ GEM
       slop (~> 3.6)
     celluloid (0.16.0)
       timers (~> 4.0.0)
+    climate_control (0.0.3)
+      activesupport (>= 3.0)
+    cocaine (0.5.7)
+      climate_control (>= 0.0.3, < 1.0)
     columnize (0.9.0)
     connection_pool (2.1.1)
     debugger-linecache (1.2.0)
@@ -97,6 +101,11 @@ GEM
     nokogiri (1.6.6.2)
       mini_portile (~> 0.6.0)
     orm_adapter (0.5.0)
+    paperclip (4.2.1)
+      activemodel (>= 3.0.0)
+      activesupport (>= 3.0.0)
+      cocaine (~> 0.5.3)
+      mime-types
     pg (0.18.1)
     puma (2.11.0)
       rack (>= 1.1, < 2.0)
@@ -194,6 +203,7 @@ DEPENDENCIES
   faraday (~> 0.9.1)
   kaminari
   lograge
+  paperclip
   pg
   puma
   rails (= 4.2.0)

--- a/app/controllers/images_controller.rb
+++ b/app/controllers/images_controller.rb
@@ -55,6 +55,7 @@ class ImagesController < ApplicationController
     
     assign_params = image_params.dup
     assign_params[:bytes] = uploaded_file.try(:size)
+    assign_params[:shortcode] = SecureRandom.hex(4) if assign_params[:shortcode].blank?
     assign_params.delete(:file)
 
     @image = Image.new(assign_params)

--- a/app/models/image.rb
+++ b/app/models/image.rb
@@ -2,6 +2,8 @@ class Image < ActiveRecord::Base
   has_many :favorites
   has_many :passes
 
+  has_attached_file :file
+  validates_attachment :file, content_type: { content_type: 'image/gif' }
   validates :original_source, uniqueness: true
 
   scope :small, ->{ where('bytes < ?', 5.megabytes) }

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -78,4 +78,14 @@ Rails.application.configure do
   config.active_record.dump_schema_after_migration = false
 
   config.lograge.enabled = true
+
+  # AWS configuration variables
+  config.paperclip_defaults = {
+    storage: :s3,
+    s3_credentials: {
+      bucket: ENV['S3_BUCKET_NAME'],
+      access_key_id: ENV['AWS_ACCESS_KEY_ID'],
+      secret_access_key: ENV['AWS_SECRET_ACCESS_KEY']
+    }
+  }
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,7 +1,7 @@
 Rails.application.routes.draw do
   devise_for :users, controllers: {registrations: "registrations", sessions: "sessions"}
 
-  resources :images, only: [:index, :create] do
+  resources :images, only: [:index] do
     get :favorites, on: :collection
     resources :favorites, only: [:create]
     resources :passes, only: [:create]
@@ -14,6 +14,6 @@ Rails.application.routes.draw do
   get "/404", :to => "errors#not_found"
   get "/500", :to => "errors#error"
 
-  resources :images, only: [:index]
+  resources :images, only: [:index, :create]
   get "shortcode/:shortcode", to: 'images#shortcode'
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,7 +1,7 @@
 Rails.application.routes.draw do
   devise_for :users, controllers: {registrations: "registrations", sessions: "sessions"}
 
-  resources :images, only: [:index] do
+  resources :images, only: [:index, :create] do
     get :favorites, on: :collection
     resources :favorites, only: [:create]
     resources :passes, only: [:create]

--- a/db/migrate/20150310000235_add_attachment_file_to_images.rb
+++ b/db/migrate/20150310000235_add_attachment_file_to_images.rb
@@ -1,0 +1,11 @@
+class AddAttachmentFileToImages < ActiveRecord::Migration
+  def self.up
+    change_table :images do |t|
+      t.attachment :file
+    end
+  end
+
+  def self.down
+    remove_attachment :images, :file
+  end
+end

--- a/db/migrate/20150317165624_change_column_original_source_from_image.rb
+++ b/db/migrate/20150317165624_change_column_original_source_from_image.rb
@@ -1,0 +1,5 @@
+class ChangeColumnOriginalSourceFromImage < ActiveRecord::Migration
+  def change
+    change_column_null(:images, :original_source, true)
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20150302231524) do
+ActiveRecord::Schema.define(version: 20150310000235) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -26,14 +26,18 @@ ActiveRecord::Schema.define(version: 20150302231524) do
   add_index "favorites", ["image_id", "user_id"], name: "index_favorites_on_image_id_and_user_id", unique: true, using: :btree
 
   create_table "images", id: :uuid, default: "uuid_generate_v4()", force: :cascade do |t|
-    t.datetime "created_at",                       null: false
-    t.string   "name",                             null: false
-    t.string   "original_source",                  null: false
-    t.string   "state",            default: "new"
-    t.integer  "bytes",                            null: false
-    t.string   "shortcode",                        null: false
-    t.integer  "favorite_counter", default: 0,     null: false
-    t.integer  "pass_counter",     default: 0,     null: false
+    t.datetime "created_at",                        null: false
+    t.string   "name",                              null: false
+    t.string   "original_source",                   null: false
+    t.string   "state",             default: "new"
+    t.integer  "bytes",                             null: false
+    t.string   "shortcode",                         null: false
+    t.integer  "favorite_counter",  default: 0,     null: false
+    t.integer  "pass_counter",      default: 0,     null: false
+    t.string   "file_file_name"
+    t.string   "file_content_type"
+    t.integer  "file_file_size"
+    t.datetime "file_updated_at"
   end
 
   add_index "images", ["shortcode"], name: "index_images_on_shortcode", unique: true, using: :btree
@@ -56,8 +60,6 @@ ActiveRecord::Schema.define(version: 20150302231524) do
     t.inet     "last_sign_in_ip"
     t.datetime "created_at"
     t.datetime "updated_at"
-    t.string   "password_hash"
-    t.string   "password_salt"
     t.string   "encrypted_password"
     t.text     "fb_auth_token"
   end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20150310000235) do
+ActiveRecord::Schema.define(version: 20150317165624) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -28,7 +28,7 @@ ActiveRecord::Schema.define(version: 20150310000235) do
   create_table "images", id: :uuid, default: "uuid_generate_v4()", force: :cascade do |t|
     t.datetime "created_at",                        null: false
     t.string   "name",                              null: false
-    t.string   "original_source",                   null: false
+    t.string   "original_source"
     t.string   "state",             default: "new"
     t.integer  "bytes",                             null: false
     t.string   "shortcode",                         null: false

--- a/spec/controllers/images_controller_spec.rb
+++ b/spec/controllers/images_controller_spec.rb
@@ -26,12 +26,75 @@ RSpec.describe ImagesController, type: :controller do
   end
 
   describe '#create' do
-    context 'when the data is valid' do
+    context 'when there is a valid auth token header' do
+      before do
+        user = create(:user)
+        request.headers['X-User-Token'] = user.authentication_token
+      end
 
+      context 'when receiving an external image' do
+        it 'creates a brand new image' do
+          image_data = valid_image_data
+          image_data.delete(:file)
+
+          post :create, image: image_data
+
+          expect(Image.count).to eq(1)
+          expect(response.status).to eql(201)
+          expect(response.body['id']).to_not be_nil
+          expect(response.body['errors']).to be_nil
+        end
+      end
+
+      context 'when receiving an image file' do
+        it 'creates a brand new image' do
+          post :create, image: valid_image_data
+
+          expect(Image.count).to eq(1)
+          expect(response.status).to eql(201)
+          expect(response.body['id']).to_not be_nil
+          expect(response.body['errors']).to be_nil
+        end
+      end
+
+      context 'when receiving incomplete params' do
+        it 'does not create an image' do
+          image_data = valid_image_data
+          image_data[:file].delete(:content_type)
+
+          post :create, image: image_data
+
+          expect(Image.count).to eq(0)
+          expect(response.status).to eql(422)
+          expect(response.body['errors']).to_not be_nil
+        end
+      end
     end
 
-    context 'when the data is invalid' do
+    context 'when there is not a valid auth token header' do
+      it 'does not create an image' do
+        post :create, image: valid_image_data
 
+        expect(Image.count).to eq(0)
+        expect(response.status).to eql(401)
+      end
     end
+  end
+
+  private
+  def valid_image_data
+    image = build(:image)
+
+    {
+      name: image.name,
+      original_source: image.original_source,
+      bytes: image.bytes,
+      shortcode: image.shortcode,
+      file: {
+        filename: 'filename.gif',
+        content: 'iVBORw0KGgoAAAANSUhEUgAAACgAAAAoCAIAAAADnC86AAAKMGlDQ1BJQ0MgUHJvZmlsZQAAeJydlndUVNcWh8+9d3qhzTAUKUPvvQ0gvTep0kRhmBlgKAMOMzSxIaICEUVEBBVBgiIGjIYisSKKhYBgwR6QIKDEYBRRUXkzslZ05eW9l5ffH2d9a5+99z1n733WugCQvP25vHRYCoA0noAf4uVKj4yKpmP7AQzwAAPMAGCyMjMCQj3DgEg+Hm70TJET+CIIgDd3xCsAN428g+h08P9JmpXBF4jSBInYgs3JZIm4UMSp2YIMsX1GxNT4FDHDKDHzRQcUsbyYExfZ8LPPIjuLmZ3GY4tYfOYMdhpbzD0i3pol5IgY8RdxURaXky3iWyLWTBWmcUX8VhybxmFmAoAiie0CDitJxKYiJvHDQtxEvBQAHCnxK47/igWcHIH4Um7pGbl8bmKSgK7L0qOb2doy6N6c7FSOQGAUxGSlMPlsult6WgaTlwvA4p0/S0ZcW7qoyNZmttbWRubGZl8V6r9u/k2Je7tIr4I/9wyi9X2x/ZVfej0AjFlRbXZ8scXvBaBjMwDy97/YNA8CICnqW/vAV/ehieclSSDIsDMxyc7ONuZyWMbigv6h/+nwN/TV94zF6f4oD92dk8AUpgro4rqx0lPThXx6ZgaTxaEb/XmI/3HgX5/DMISTwOFzeKKIcNGUcXmJonbz2FwBN51H5/L+UxP/YdiftDjXIlEaPgFqrDGQGqAC5Nc+gKIQARJzQLQD/dE3f3w4EL+8CNWJxbn/LOjfs8Jl4iWTm/g5zi0kjM4S8rMW98TPEqABAUgCKlAAKkAD6AIjYA5sgD1wBh7AFwSCMBAFVgEWSAJpgA+yQT7YCIpACdgBdoNqUAsaQBNoASdABzgNLoDL4Dq4AW6DB2AEjIPnYAa8AfMQBGEhMkSBFCBVSAsygMwhBuQIeUD+UAgUBcVBiRAPEkL50CaoBCqHqqE6qAn6HjoFXYCuQoPQPWgUmoJ+h97DCEyCqbAyrA2bwAzYBfaDw+CVcCK8Gs6DC+HtcBVcDx+D2+EL8HX4NjwCP4dnEYAQERqihhghDMQNCUSikQSEj6xDipFKpB5pQbqQXuQmMoJMI+9QGBQFRUcZoexR3qjlKBZqNWodqhRVjTqCakf1oG6iRlEzqE9oMloJbYC2Q/ugI9GJ6Gx0EboS3YhuQ19C30aPo99gMBgaRgdjg/HGRGGSMWswpZj9mFbMecwgZgwzi8ViFbAGWAdsIJaJFWCLsHuxx7DnsEPYcexbHBGnijPHeeKicTxcAa4SdxR3FjeEm8DN46XwWng7fCCejc/Fl+Eb8F34Afw4fp4gTdAhOBDCCMmEjYQqQgvhEuEh4RWRSFQn2hKDiVziBmIV8TjxCnGU+I4kQ9InuZFiSELSdtJh0nnSPdIrMpmsTXYmR5MF5O3kJvJF8mPyWwmKhLGEjwRbYr1EjUS7xJDEC0m8pJaki+QqyTzJSsmTkgOS01J4KW0pNymm1DqpGqlTUsNSs9IUaTPpQOk06VLpo9JXpSdlsDLaMh4ybJlCmUMyF2XGKAhFg+JGYVE2URoolyjjVAxVh+pDTaaWUL+j9lNnZGVkLWXDZXNka2TPyI7QEJo2zYeWSiujnaDdob2XU5ZzkePIbZNrkRuSm5NfIu8sz5Evlm+Vvy3/XoGu4KGQorBToUPhkSJKUV8xWDFb8YDiJcXpJdQl9ktYS4qXnFhyXwlW0lcKUVqjdEipT2lWWUXZSzlDea/yReVpFZqKs0qySoXKWZUpVYqqoypXtUL1nOozuizdhZ5Kr6L30GfUlNS81YRqdWr9avPqOurL1QvUW9UfaRA0GBoJGhUa3RozmqqaAZr5ms2a97XwWgytJK09Wr1ac9o62hHaW7Q7tCd15HV8dPJ0mnUe6pJ1nXRX69br3tLD6DH0UvT2693Qh/Wt9JP0a/QHDGADawOuwX6DQUO0oa0hz7DecNiIZORilGXUbDRqTDP2Ny4w7jB+YaJpEm2y06TX5JOplWmqaYPpAzMZM1+zArMus9/N9c1Z5jXmtyzIFp4W6y06LV5aGlhyLA9Y3rWiWAVYbbHqtvpobWPNt26xnrLRtImz2WczzKAyghiljCu2aFtX2/W2p23f2VnbCexO2P1mb2SfYn/UfnKpzlLO0oalYw7qDkyHOocRR7pjnONBxxEnNSemU73TE2cNZ7Zzo/OEi55Lsssxlxeupq581zbXOTc7t7Vu590Rdy/3Yvd+DxmP5R7VHo891T0TPZs9Z7ysvNZ4nfdGe/t57/Qe9lH2Yfk0+cz42viu9e3xI/mF+lX7PfHX9+f7dwXAAb4BuwIeLtNaxlvWEQgCfQJ3BT4K0glaHfRjMCY4KLgm+GmIWUh+SG8oJTQ29GjomzDXsLKwB8t1lwuXd4dLhseEN4XPRbhHlEeMRJpEro28HqUYxY3qjMZGh0c3Rs+u8Fixe8V4jFVMUcydlTorc1ZeXaW4KnXVmVjJWGbsyTh0XETc0bgPzEBmPXM23id+X/wMy421h/Wc7cyuYE9xHDjlnIkEh4TyhMlEh8RdiVNJTkmVSdNcN24192Wyd3Jt8lxKYMrhlIXUiNTWNFxaXNopngwvhdeTrpKekz6YYZBRlDGy2m717tUzfD9+YyaUuTKzU0AV/Uz1CXWFm4WjWY5ZNVlvs8OzT+ZI5/By+nL1c7flTuR55n27BrWGtaY7Xy1/Y/7oWpe1deugdfHrutdrrC9cP77Ba8ORjYSNKRt/KjAtKC94vSliU1ehcuGGwrHNXpubiySK+EXDW+y31G5FbeVu7d9msW3vtk/F7OJrJaYllSUfSlml174x+6bqm4XtCdv7y6zLDuzA7ODtuLPTaeeRcunyvPKxXQG72ivoFcUVr3fH7r5aaVlZu4ewR7hnpMq/qnOv5t4dez9UJ1XfrnGtad2ntG/bvrn97P1DB5wPtNQq15bUvj/IPXi3zquuvV67vvIQ5lDWoacN4Q293zK+bWpUbCxp/HiYd3jkSMiRniabpqajSkfLmuFmYfPUsZhjN75z/66zxailrpXWWnIcHBcef/Z93Pd3Tvid6D7JONnyg9YP+9oobcXtUHtu+0xHUsdIZ1Tn4CnfU91d9l1tPxr/ePi02umaM7Jnys4SzhaeXTiXd272fMb56QuJF8a6Y7sfXIy8eKsnuKf/kt+lK5c9L1/sdek9d8XhyumrdldPXWNc67hufb29z6qv7Sern9r6rfvbB2wGOm/Y3ugaXDp4dshp6MJN95uXb/ncun572e3BO8vv3B2OGR65y747eS/13sv7WffnH2x4iH5Y/EjqUeVjpcf1P+v93DpiPXJm1H2070nokwdjrLHnv2T+8mG88Cn5aeWE6kTTpPnk6SnPqRvPVjwbf57xfH666FfpX/e90H3xw2/Ov/XNRM6Mv+S/XPi99JXCq8OvLV93zwbNPn6T9mZ+rvitwtsj7xjvet9HvJ+Yz/6A/VD1Ue9j1ye/Tw8X0hYW/gUDmPP8uaxzGQAACgZJREFUeJxlWEusbNdRXauq9jndfT/vY5NnEwslNlLiEHD4xYkeJlbCKCITJhFYCpMIIoHEiAmRkSAoUsQkQxggPhLCGQAiIgqfIAySJchPRIlkLONgB0HiF/l97nu3u8/Zu6oY7O5+78lHd9Cn7+7atVdVrVq1+cGnrpLMTJIRWUxba6oKgCTIiCAJICIyAmRrjWRrDYCZZYSqiioyAYKI/o1IRkzTRBFT22w33aaIZKYByMxwV9t9NrPIRO4eABCptfZtuh8kVdWbA6DIwfVugQBJd2+tmVlrLST604+02xiZFMlIEtM8E8jMYRjULCMjw91rrcMwZGY/RwdAVEQkIjJTRXzvU3eutYbMiAAgIkdHRwe3QBoSEQlkkkJBAgQAkB1YJFR1uViIagegL+nuH2CJCBHpDgEAYKq11sxUMxEREW+tDAMySVoiSZASHVVkJhLIiPU8D6WoWcTO9AHMiDCzzHTfoZ2Z7D5k9u3VbPc9+3+SIhHRz2XjOO4C2U32X5KRqaKRub1zhxRVAdBa84jlYlHGsS8DEO7jOLr7nfPzo9WqlBIRc63u3pE/hJ87MAHAkKkizb3bPSTLATF3d587jMMw1FpVtZjt3CVDRERa8/7aVxLs+XnYKSJabcM4JJCZQtIj+gozE0rHmmQiu8uyf3Ym9gkfHXT3zFSV5WIxDsO9mx2efpK5zodX66Ht0SIYGQDcm5UiAlOqUkVVBWS32VqbyF7BzT0jylDmWlutABaLRQ/bvbu6+zRNADabze6Q8zRZKb3IdlkQaUWFON8kmefnUecZoAgeuLTqwSapIhBR1Xmet9tpmqaj1erW2dlc64XT0zeferef6lxrZJqVIqR3ngIAqrE5auN7f3T1nneWS8fLzLy9xsvfaS987fzsjl8e7yZJ5ywzG4dBRC5evDjP8yE/3rx3DysB2+93gCXnOZeLfPYTF5766QEKmGAENonAq6+dfPoPz7758qzqnXxaa+E+ue9+DmTmer3G/WY75yyXS5LFrLYmBwczswdmvd4++/GTp352Uc+jbfL1V+e//av1fNPnM3/b24ZPfvzCONAjD7kame6+y7MIAB5BUHj423GqkGMnxEyr8ywkRQAIud7G+55YPfX+43bdSdqS33y5/uZnz4+PLjz9oYLzuHKZR0uuN6GSkXRvwiyDEfRwACLanED00+NA4OQ0z+7uERFhpRR0v8xIXLteH390lYVYJwgQ1QHEZ/98c3Qkb7lin/v85rXv4eRonO7IWHKaZbOpVohkZCAxFDleYZrRYlDJ9XYqxuOljDJ2ghIRVeUHf+ZqZhQzT7l8ig89aVefGH7knWPOCUAGvvLf9V++XuvmVtT1amU3brZxAEUXQ37j24uHH7rwAw9E1FQV9xDj9Rvx3D+sH3kQH35yevuVaT3hC/82fuu1o9UiE5ROdplGwsqAjFrjZKW/+swJGnLOnhw552M/pI+9Y5Fv3Di/fgNiRTMS4Tg6jj/+4qX3vffK4z8p2BJIBHHMF78yf+PFW7/7yzcfulxrowqe/rH1b/+ZfPml5fEyI4FEIq01j0xkbNZ1OxUEEPcUIXdk4I5MTFXubHoPAMjNlCCwzflWiiAjZeZo7Xc+dv2RB/3aTVNNd5yu8hefPvvKS2WuCYAUALJYLlqt7lGKTVX+7vnNa//rKNi1GeV3r/k/Pr/50lf5pf84uX4mg0EIEaikKf7py9N/vdJshBBmEJdH31qv3bS//9rp8TIImGGqfPiyXz7x5hxK6eJEaq0RmZnF8vqt+I3P3Hj+q1suJAKR4IJf/8/665++9qk/td977qFvf7eMw65/JmCK3/+T21/8540sGd1Rye3Ez3zu4l++cIl7tECQEEFEeocOkO1mC6SqqZqpvOWBcbUwZO5BznGQyxfK6QonSx8HycBd3iIvnthyIYi+Fiz52vfKd75vq0XUdh+LqKhIJ/wMd1GVXmwdfoCZ9xGeiCwWo0dOc6vVuVsKJEQ6AdzbZ+EBVdzHmgkAZqq9kEQSEDMT4YE4b9z2ab73TNhs/fXvb+fZw51E7tsOiQy0Fu95bA3f/57wwI1b4Y6Dh93aXKtHtNa6aBGQVoqaDmUA8hO/UH7q3ZoThBAiJ7zrUfvkrxw9cqUECiDdmBBT5ROPTs8+88aPPzblRJEkkTUfuWKf+rXTy6d+F+oEiGEYzKzVmpHDMAgyCWSn2cyPfeTk8Xcs2iYiEQmf8u1vtWc+evrQgyWyvHptGApaMIH1JI8+PH3kyZsv/s8ykM0RCZ9x6VQ++vPHF084VUTAAx6IIBLzPKlqZmSEHbRjhCsRCYwsor3RgIADgWmu0aa/eaFcfZf98A/W7SymQfIPvnDl9IHTd3+AeiaQfYAaTXHhKIbCCKigFEQ0M1ssynY7NXfLTFVVkYgk4/PP37lwQbJBhQeJD8H1Wzhe2Y07+K0/uvxLPzc/fGl640z/9VtH//7SyQd+oj33F1u6yT4zprm98n/y1y8cqwAQIFrINIuSFBnGsc6VT199/1DKTicRr187cw+Qpnp0dJRAbydHSxFJIac5tRwJfa4pgpNl1rDXX7+hpqUMQNa5ureTk8XcdvXS3FXkZEUiY684DZm1VjUj0Gq7eGq9nYlqKUHQIzMymRlwpmmsxuqeJo5EbWrmD1yyiCQrkBgAlkQsBmCv78kAJRNdMWam9Qmsv7TWlsuVmW6324ggVUQjkSJMUEGA1Fu3zwGM44jEdjonuVwszO7WcnYF7nsYAVD6oNXzicBO6S+Xy8Vi0T97RFcUB59IikoXul0tE1RRCodhsH16drv3qssdZ+lONZuZmXXJbKWUrlr2ej+F2ifJPtnt7SVFsJfcQHq4qmbE7K6qtbVaa61VRFar1WFvFSUlM0gOpYBcr9e7UXUYx9042+lbOp2Jmd3LnTwARVIk3Am4R2SKKsla63K57FR8oMJEdgbLzM12e37nzo6Caq3hLiIdXgCZkYCout/l217uO3O5mw3dvXk7rCmlbLfbvvjwZUT4nvwjIgE1RcK6Iu81I6o9F/Z5kn28P+hI7kYaZmTsB/AOlZCLcYxSRIQirbWDoxFB7Ij77lVCGYb+XrrQ3Kd7rygAm82m1np8fGxmt2/fzsyLly718NdaF+PCTGut/Y4Ave7dhaRqv0d4U7ZBVE1Ij5Bdh9rxZK01IlSNyogspaxWqx7F9XrdrXeNfgCHIu7e4w8EudN12E9sqtJ7rqgSEPYeCUaEhwPseSsivTGTaK211iJynueOXmttO024e0sCANJb/T2PiBQrexQhQlXLyNbckCDQWu2Zub9oILCfpsle07GfZjs2Hdh+vQKAYESfxGV/ThYzEYmUThXhHpmmmoBFRkYuFou2z2oKRejeR+xdBZcyqIqqdgo0U0npKXl/xe3T8h5KOdwLtOaZUeeayP8HTz8KI7RU1MEAAAAASUVORK5CYII=',
+        content_type: 'image/gif'
+      }
+    }
   end
 end

--- a/spec/controllers/images_controller_spec.rb
+++ b/spec/controllers/images_controller_spec.rb
@@ -24,4 +24,14 @@ RSpec.describe ImagesController, type: :controller do
       end
     end
   end
+
+  describe '#create' do
+    context 'when the data is valid' do
+
+    end
+
+    context 'when the data is invalid' do
+
+    end
+  end
 end


### PR DESCRIPTION
This bounty isn't finished yet.
We can now create images by uploading a file (actually, a Base64 encoded string).
Just including the "file" node with its attributes to the payload should upload the image to the S3 bucket.

Payload example:
{
  "image": {
    "name": "Freak Image",
    "original_source": "http://i.imgur.com/1s72yIt.gif",
    "bytes": 5432,
    "shortcode": "1s72yIt",
    // include this node to send a file
    "file": {
      "filename": "original_filename.gif",
      "content": "R0lGODlhgACAAKUAAAQCBISChMTC...", // (Base64 encoded
string)
      "content_type": "image/gif"
    }
  }
}

I'm not sure how to handle "original_source" and "shortcode" when the file is uploaded, because they currently are not-null in the database. Should we remove that constraint?
