### PR TITLE
Support anonymous login (bounties/180)

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -28,6 +28,7 @@ group :development, :test do
   gem 'byebug'
   gem 'factory_girl_rails'
   gem 'rspec-rails', '~> 3.2'
+  gem 'shoulda-matchers'
   gem 'spring'
   gem 'timecop'
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -182,6 +182,8 @@ GEM
       rspec-mocks (~> 3.2.0)
       rspec-support (~> 3.2.0)
     rspec-support (3.2.1)
+    shoulda-matchers (2.8.0)
+      activesupport (>= 3.0.0)
     sidekiq (3.3.1)
       celluloid (>= 0.16.0)
       connection_pool (>= 2.1.1)
@@ -247,6 +249,7 @@ DEPENDENCIES
   rails_stdout_logging
   responders (~> 2.0)
   rspec-rails (~> 3.2)
+  shoulda-matchers
   sidekiq
   sinatra
   spring

--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -18,8 +18,7 @@ class SessionsController < ApplicationController
   end
 
   def fbcreate
-    @user = User.create_with(fb_auth_token: params[:fb_auth_token])
-                .find_or_create_by(email: params[:email])
+    @user = User.create_with(fb_auth_token: params[:fb_auth_token]).find_or_create_by(email: params[:email])
 
     return invalid_login_attempt if params[:fb_auth_token].blank?
 

--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -6,9 +6,7 @@ class SessionsController < ApplicationController
     return invalid_login_attempt unless @user.valid?
 
     if @user.valid_password?(params[:password])
-
       @user.update! authentication_token: @user.generate_auth_token
-
       sign_in @user, store: false
       
       render json: { authentication_token: @user.authentication_token }, status: :ok
@@ -17,9 +15,29 @@ class SessionsController < ApplicationController
     invalid_login_attempt
   end
 
+  def create_anonymous
+    device = Device.create_with(kind: params[:device_type]).find_or_create_by(uid: params[:device_id])
+    return invalid_device_data(device) unless device.valid?
+    @user = device.user
+
+    unless @user
+      @user = User.create(anonymous: true)
+      @user.devices << device
+    end
+    return invalid_login_attempt unless @user.valid?
+
+    if @user.save
+      @user.update! authentication_token: @user.generate_auth_token
+      sign_in @user, store: false
+
+      render json: { authentication_token: @user.authentication_token }, status: :ok
+      return
+    end
+    invalid_login_attempt
+  end
+
   def fbcreate
     @user = User.create_with(fb_auth_token: params[:fb_auth_token]).find_or_create_by(email: params[:email])
-
     return invalid_login_attempt if params[:fb_auth_token].blank?
 
     sign_in @user, store: false
@@ -44,5 +62,9 @@ class SessionsController < ApplicationController
   protected
   def invalid_login_attempt
     render json: { message: "Invalid email or password", errors: @user.errors }, status: :unauthorized
+  end
+
+  def invalid_device_data device
+    render json: { message: "Invalid device data", errors: device.errors }, status: :unprocessable_entity
   end
 end

--- a/app/models/device.rb
+++ b/app/models/device.rb
@@ -1,0 +1,3 @@
+class Device < ActiveRecord::Base
+  belongs_to :user
+end

--- a/app/models/device.rb
+++ b/app/models/device.rb
@@ -1,3 +1,5 @@
 class Device < ActiveRecord::Base
   belongs_to :user
+
+  validates :uid, presence: true
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -17,9 +17,8 @@ class User < ActiveRecord::Base
   end
 
   private
-    def set_auth_token
-      return if authentication_token.present?
-      self.authentication_token = generate_auth_token
-    end
-
+  def set_auth_token
+    return if authentication_token.present?
+    self.authentication_token = generate_auth_token
+  end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -3,6 +3,7 @@ class User < ActiveRecord::Base
   has_many :favorite_images, source: :image, through: :favorites
   has_many :passes
   has_many :passed_images, source: :image, through: :passes
+  has_many :devices
 
   devise :database_authenticatable, :registerable, :trackable
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -17,6 +17,7 @@ Rails.application.routes.draw do
   resources :sessions, only: [:create, :destroy]
 
   post "/fbcreate", :to => "sessions#fbcreate"
+  post "/create_anonymous", :to => "sessions#create_anonymous"
 
   get "/404", :to => "errors#not_found"
   get "/500", :to => "errors#error"

--- a/db/migrate/20150430002605_add_anonymous_to_user.rb
+++ b/db/migrate/20150430002605_add_anonymous_to_user.rb
@@ -1,0 +1,5 @@
+class AddAnonymousToUser < ActiveRecord::Migration
+  def change
+    add_column :users, :anonymous, :boolean, default: false
+  end
+end

--- a/db/migrate/20150430003542_create_devices.rb
+++ b/db/migrate/20150430003542_create_devices.rb
@@ -1,9 +1,9 @@
 class CreateDevices < ActiveRecord::Migration
   def change
-    create_table :devices do |t|
+    create_table :devices, id: :uuid do |t|
       t.string :uid, null: false
       t.string :kind
-      t.references :user
+      t.uuid :user_id
 
       t.timestamps null: false
     end

--- a/db/migrate/20150430003542_create_devices.rb
+++ b/db/migrate/20150430003542_create_devices.rb
@@ -1,0 +1,11 @@
+class CreateDevices < ActiveRecord::Migration
+  def change
+    create_table :devices do |t|
+      t.string :uid, null: false
+      t.string :type
+      t.references :user
+
+      t.timestamps null: false
+    end
+  end
+end

--- a/db/migrate/20150430003542_create_devices.rb
+++ b/db/migrate/20150430003542_create_devices.rb
@@ -2,7 +2,7 @@ class CreateDevices < ActiveRecord::Migration
   def change
     create_table :devices do |t|
       t.string :uid, null: false
-      t.string :type
+      t.string :kind
       t.references :user
 
       t.timestamps null: false

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20150401220402) do
+ActiveRecord::Schema.define(version: 20150430002605) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -65,19 +65,18 @@ ActiveRecord::Schema.define(version: 20150401220402) do
   add_index "twitter_posts", ["rid"], name: "index_twitter_posts_on_rid", using: :btree
 
   create_table "users", id: :uuid, default: "uuid_generate_v4()", force: :cascade do |t|
-    t.string   "authentication_token",             null: false
+    t.string   "authentication_token",                 null: false
     t.string   "email"
-    t.integer  "sign_in_count",        default: 0, null: false
+    t.integer  "sign_in_count",        default: 0,     null: false
     t.datetime "current_sign_in_at"
     t.datetime "last_sign_in_at"
     t.inet     "current_sign_in_ip"
     t.inet     "last_sign_in_ip"
     t.datetime "created_at"
     t.datetime "updated_at"
-    t.string   "password_hash"
-    t.string   "password_salt"
     t.string   "encrypted_password"
     t.text     "fb_auth_token"
+    t.boolean  "anonymous",            default: false
   end
 
   add_index "users", ["authentication_token"], name: "index_users_on_authentication_token", using: :btree

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -17,10 +17,10 @@ ActiveRecord::Schema.define(version: 20150430003542) do
   enable_extension "plpgsql"
   enable_extension "uuid-ossp"
 
-  create_table "devices", force: :cascade do |t|
+  create_table "devices", id: :uuid, default: "uuid_generate_v4()", force: :cascade do |t|
     t.string   "uid",        null: false
     t.string   "kind"
-    t.integer  "user_id"
+    t.uuid     "user_id"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
   end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -19,7 +19,7 @@ ActiveRecord::Schema.define(version: 20150430003542) do
 
   create_table "devices", force: :cascade do |t|
     t.string   "uid",        null: false
-    t.string   "type"
+    t.string   "kind"
     t.integer  "user_id"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,11 +11,19 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20150430002605) do
+ActiveRecord::Schema.define(version: 20150430003542) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
   enable_extension "uuid-ossp"
+
+  create_table "devices", force: :cascade do |t|
+    t.string   "uid",        null: false
+    t.string   "type"
+    t.integer  "user_id"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+  end
 
   create_table "favorites", id: :uuid, default: "uuid_generate_v4()", force: :cascade do |t|
     t.datetime "created_at", null: false

--- a/spec/controllers/sessions_controller_spec.rb
+++ b/spec/controllers/sessions_controller_spec.rb
@@ -4,7 +4,7 @@ RSpec.describe SessionsController, type: :controller do
   describe '#create' do
     
     context 'when the data is valid' do
-      it 'creates brand new user' do
+      it 'creates a brand new user' do
         post :create, email: 'finn@ooo.com', password: 'testpass'
 
         expect(User.count).to eq(1)
@@ -42,4 +42,59 @@ RSpec.describe SessionsController, type: :controller do
       end
     end
   end
+
+  describe '#create_anonymous' do
+    before do
+      @device_attrs = attributes_for(:device)
+    end
+    
+    context 'when the data is valid' do
+      context 'when the user does not exist' do
+        it 'creates a brand new anonymous user' do
+          post :create_anonymous, device_id: @device_attrs[:uid], device_type: @device_attrs[:kind]
+
+          expect(User.count).to eq(1)
+          expect(assigns(:user).devices.count).to eq(1)
+          expect(assigns(:user).anonymous).to be_truthy
+          expect(assigns(:user).authentication_token).to_not be_nil
+          expect(response.status).to eql(200)
+        end
+      end
+
+      context 'when the user already exists' do
+        before do
+          @user = create(:anonymous_user)
+          @device = create(:device, user: @user)
+        end
+
+        it 'does not create a new user' do
+          post :create_anonymous, device_id: @device.uid, device_type: @device.kind
+
+          expect(User.count).to eq(1)
+          expect(assigns(:user).devices.count).to eq(1)
+          expect(response.status).to eql(200)
+        end
+
+        it 'updates authentication_token if user logs in correctly' do
+          old_auth_token = @user.authentication_token
+
+          post :create_anonymous, device_id: @device.uid, device_type: @device.kind
+          
+          expect(old_auth_token).to_not eq(response.body["authentication_token"])
+          expect(response.status).to eql(200)
+        end
+      end
+    end
+
+    context 'when the data is invalid' do
+      it 'does not create an user without device id' do
+        post :create_anonymous, device_type: @device_attrs[:kind]
+
+        expect(User.count).to eq(0)
+        expect(response.status).to eql(401)
+        expect(response.body['errors']).to_not be_nil
+      end
+    end
+  end
+
 end

--- a/spec/factories.rb
+++ b/spec/factories.rb
@@ -1,7 +1,7 @@
 FactoryGirl.define do
   factory :device do
     uid  {|n| "device_#{n}"}
-    type "iphone"
+    kind "iphone"
     user
   end
 

--- a/spec/factories.rb
+++ b/spec/factories.rb
@@ -1,6 +1,6 @@
 FactoryGirl.define do
   factory :device do
-    uid  {|n| "device_#{n}"}
+    sequence(:uid) {|n| "device_#{n}"}
     kind "iphone"
     user
   end
@@ -20,5 +20,11 @@ FactoryGirl.define do
   factory :user do
     sequence(:email) {|n| "email_#{n}@foo.bar"}
     sequence(:password) {|n| "password-#{n}"}
+
+    factory :anonymous_user do
+      anonymous true
+      email nil
+      password nil
+    end
   end
 end

--- a/spec/factories.rb
+++ b/spec/factories.rb
@@ -1,9 +1,12 @@
 FactoryGirl.define do
-
-  factory :twitter_post do
-    
+  factory :device do
+    uid  {|n| "device_#{n}"}
+    type "iphone"
+    user
   end
 
+  factory :twitter_post do    
+  end
 
   factory :image do
     name {|n| "Caption #{n}" }

--- a/spec/models/device_spec.rb
+++ b/spec/models/device_spec.rb
@@ -1,0 +1,4 @@
+require 'rails_helper'
+
+RSpec.describe Device, type: :model do
+end

--- a/spec/models/device_spec.rb
+++ b/spec/models/device_spec.rb
@@ -1,4 +1,5 @@
 require 'rails_helper'
 
 RSpec.describe Device, type: :model do
+  it { should belong_to :user }
 end

--- a/spec/models/device_spec.rb
+++ b/spec/models/device_spec.rb
@@ -2,4 +2,5 @@ require 'rails_helper'
 
 RSpec.describe Device, type: :model do
   it { should belong_to :user }
+  it { should validate_presence_of :uid }
 end

--- a/spec/models/twitter_post_spec.rb
+++ b/spec/models/twitter_post_spec.rb
@@ -1,5 +1,4 @@
 require 'rails_helper'
 
 RSpec.describe TwitterPost, type: :model do
-  pending "add some examples to (or delete) #{__FILE__}"
 end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -1,6 +1,8 @@
 require 'rails_helper'
 
 RSpec.describe User, type: :model do
+  it { should have_many :devices }
+
   let(:user)     { create(:user) }
   let(:favorite) { Favorite.create!(user: user, image: create(:image)) }
   let(:pass)     { Pass.create!(user: user, image: create(:image)) }


### PR DESCRIPTION
This PR creates an endpoint in order to support anonymous login in the Fun app (bounty [#180](https://assembly.com/giraff/bounties/180)).

The payload for the endpoint `/create_anonymous` should be:

```
{
    "device_type": "iphone 5s",
    "device_id": "some unique device identifier"
}
```

The `session#create_anonymous` method creates an user with the flag `anonymous: true`, and email and password are not required. It also associate a new device with this user, containing an unique device id and its type.

When this user signs up anytime later from the same device, the method `create` updates the existent user record with the email and password provided.
